### PR TITLE
Add alpha and line_end options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ganttrify
 Title: Create beautiful Gantt charts with ggplot2
-Version: 0.0.0.9004
+Version: 0.0.0.9005
 Authors@R: 
     person(given = "Giorgio",
            family = "Comai (OBCT/CCI)",

--- a/man/ganttrify.Rd
+++ b/man/ganttrify.Rd
@@ -21,7 +21,10 @@ ganttrify(
   month_number_label = TRUE,
   month_date_label = TRUE,
   x_axis_position = "top",
-  colour_stripe = "lightgray"
+  colour_stripe = "lightgray",
+  alpha_wp = 1,
+  alpha_activity = 1,
+  line_end = "round"
 )
 }
 \arguments{
@@ -58,6 +61,12 @@ ganttrify(
 \item{x_axis_position}{Logical, defaults to "top". Can also be "bottom". Used only when only one of `month_number_label` and `month_date_label` is TRUE, otherwise ignored.}
 
 \item{colour_stripe}{Character, defaults to "lightgray". This is the stripe colour in the background used in alternate months.}
+
+\item{alpha_wp}{Numeric, defaults to 1. Controls transparency of the line used to represent WPs.}
+
+\item{alpha_activity}{Numeric, defaults to 1. Controls transparency of the line used to represent activities.}
+
+\item{line_end}{Character, defaults to "round". One of "round", "butt", "square". Controls line ends.}
 }
 \value{
 A Gantt chart as a ggplot2 object.


### PR DESCRIPTION
Thanks for your great package! For my personal usage, I added arguments for line-endings and transparency (see attached plot for an example). Default behavior should stay the same, though I only looked at the R-usage, not at the shiny app. Opening a pull request here as a suggestion to integrate these features.

```R
ganttrify(project = ganttrify::test_project,
                      alpha_wp = 0.9, alpha_activity = 0.6,
                      line_end = "butt")
```
![alpha_gantt](https://user-images.githubusercontent.com/16386421/111706973-875ae700-8843-11eb-88b9-c49e078ca6c9.png)
