### PR TITLE
Set font to one installed by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ served.
 ganttrify(project = ganttrify::test_project,
           spots = ganttrify::test_spots,
           project_start_date = "2021-03",
-          font_family = "Roboto Condensed")
+          font_family = "Arial")
 ```
 
 <img src="man/figures/README-gantt_charts_with_events-1.png" width="100%" />
@@ -147,7 +147,7 @@ ganttrify(project = ganttrify::test_project,
           project_start_date = "2021-03",
           size_text_relative = 1.2, 
           mark_quarters = TRUE,
-          font_family = "Roboto Condensed")
+          font_family = "Arial")
 ```
 
 <img src="man/figures/README-gantt_charts_resized_text-1.png" width="100%" />


### PR DESCRIPTION
Test code failed on my macOS RStudio installation. `Error in grid.Call(C_textBounds, as.graphicsAnnot(x$label), x$x, x$y, : polygon edge not found` . Traced to uninstalled font. Change to installed Arial font fixes issue.